### PR TITLE
v3.0.12 alpha, unknown estimate changes

### DIFF
--- a/metaphlan/metaphlan.py
+++ b/metaphlan/metaphlan.py
@@ -518,7 +518,7 @@ class TaxClade:
                     for m,n in self.markers2nreads.items()]
 
     def compute_mapped_reads( self ):
-        if self.name.startswith('k__'):
+        if self.name.startswith('s__'):
             return self.nreads
         for c in self.children.values():
             self.nreads += c.compute_mapped_reads()
@@ -770,7 +770,7 @@ class TaxTree:
                         else:
                             glen = self.all_clades[clade_label].glen
                             tax_id = self.all_clades[clade_label].get_full_taxids()
-                            if 'k__' in clade_label and abundance > 0:
+                            if 's__' in clade_label and abundance > 0:
                                 self.all_clades[clade_label].nreads = int(np.floor(abundance*glen))
 
                             clade_label = self.all_clades[clade_label].get_full_name()

--- a/metaphlan/metaphlan.py
+++ b/metaphlan/metaphlan.py
@@ -66,6 +66,9 @@ DEFAULT_DB_FOLDER= os.environ.get('METAPHLAN_DB_DIR', DEFAULT_DB_FOLDER)
 INDEX = 'latest'
 tax_units = "kpcofgst"
 
+# set default parameters
+GENOME_LENGTH_BOOST_FOR_UNKNOWN_ESTIMATE=1.05
+
 def read_params(args):
     p = ap.ArgumentParser( description=
             "DESCRIPTION\n"
@@ -676,7 +679,7 @@ class TaxTree:
                 lens.append( add_lens( c ) )
             # use a different length for the unknown calculation
             if self.unknown_calculation:
-                node.glen = np.median(lens)
+                node.glen = np.median(lens) * GENOME_LENGTH_BOOST_FOR_UNKNOWN_ESTIMATE
             else:
                 node.glen = min(np.mean(lens), np.median(lens))
             return node.glen

--- a/metaphlan/metaphlan.py
+++ b/metaphlan/metaphlan.py
@@ -969,6 +969,10 @@ def compute_relative_abundance_and_fraction_of_mapped_reads(tree, pars, n_metage
     # If the mapped reads are over-estimated, set the ratio at 1
     fraction_mapped_reads = min(tot_nreads/float(n_metagenome_reads), 1.0) if ESTIMATE_UNK else 1.0
 
+    # check for a negative fraction
+    if unknown_calculation and fraction_mapped_reads < 0:
+        fraction_mapped_reads = 1.0
+
     return cl2ab, fraction_mapped_reads
 
 def main():

--- a/metaphlan/metaphlan.py
+++ b/metaphlan/metaphlan.py
@@ -4,8 +4,8 @@ __author__ = ('Francesco Beghini (francesco.beghini@unitn.it),'
               'Duy Tin Truong, '
               'Francesco Asnicar (f.asnicar@unitn.it), '
               'Aitor Blanco Miguez (aitor.blancomiguez@unitn.it)')
-__version__ = '3.0.11'
-__date__ = '07 Jul 2021'
+__version__ = '3.0.12'
+__date__ = '14 Jul 2021'
 
 import sys
 try:

--- a/metaphlan/metaphlan.py
+++ b/metaphlan/metaphlan.py
@@ -1057,17 +1057,6 @@ def main():
         if not CAMI_OUTPUT:
             outf.write('#' + '\t'.join((pars["sample_id_key"], pars["sample_id"])) + '\n')
 
-        if ESTIMATE_UNK:
-            mapped_reads = 0
-            cl2pr = tree.clade_profiles( pars['tax_lev']+"__" if pars['tax_lev'] != 'a' else None  )
-            for c, m in cl2pr.items():
-                markers_cov = [a  / 1000 for _, a in m]
-                mapped_reads += np.mean(markers_cov) * tree.all_clades[c.split('|')[-1]].glen
-            # If the mapped reads are over-estimated, set the ratio at 1
-            fraction_mapped_reads = min(mapped_reads/float(n_metagenome_reads), 1.0)
-        else:
-            fraction_mapped_reads = 1.0
-        
         if pars['t'] == 'reads_map':
             if not MPA2_OUTPUT:
                outf.write('#read_id\tNCBI_taxlineage_str\tNCBI_taxlineage_ids\n')
@@ -1084,7 +1073,10 @@ def main():
 
             cl2ab, _, tot_nreads = tree.relative_abundances(
                         pars['tax_lev']+"__" if pars['tax_lev'] != 'a' else None )
-            
+
+            # If the mapped reads are over-estimated, set the ratio at 1
+            fraction_mapped_reads = min(tot_nreads/float(n_metagenome_reads), 1.0) if ESTIMATE_UNK else 1.0           
+ 
             outpred = [(taxstr, taxid,round(relab*100.0,5)) for (taxstr, taxid), relab in cl2ab.items() if relab > 0.0]
             has_repr = False
             
@@ -1136,6 +1128,8 @@ def main():
         elif pars['t'] == 'rel_ab_w_read_stats':
             cl2ab, rr, tot_nreads = tree.relative_abundances(
                         pars['tax_lev']+"__" if pars['tax_lev'] != 'a' else None )
+
+            fraction_mapped_reads = min(tot_nreads/float(n_metagenome_reads), 1.0) if ESTIMATE_UNK else 1.0
 
             unmapped_reads = max(n_metagenome_reads - tot_nreads, 0)
 

--- a/metaphlan/metaphlan.py
+++ b/metaphlan/metaphlan.py
@@ -518,7 +518,7 @@ class TaxClade:
                     for m,n in self.markers2nreads.items()]
 
     def compute_mapped_reads( self ):
-        if self.name.startswith('s__'):
+        if self.name.startswith('k__'):
             return self.nreads
         for c in self.children.values():
             self.nreads += c.compute_mapped_reads()
@@ -770,7 +770,7 @@ class TaxTree:
                         else:
                             glen = self.all_clades[clade_label].glen
                             tax_id = self.all_clades[clade_label].get_full_taxids()
-                            if 's__' in clade_label and abundance > 0:
+                            if 'k__' in clade_label and abundance > 0:
                                 self.all_clades[clade_label].nreads = int(np.floor(abundance*glen))
 
                             clade_label = self.all_clades[clade_label].get_full_name()

--- a/metaphlan/strainphlan.py
+++ b/metaphlan/strainphlan.py
@@ -4,8 +4,8 @@ __author__ = ('Aitor Blanco Miguez (aitor.blancomiguez@unitn.it), '
               'Francesco Asnicar (f.asnicar@unitn.it), '
               'Moreno Zolfo (moreno.zolfo@unitn.it), '
               'Francesco Beghini (francesco.beghini@unitn.it)')
-__version__ = '3.0.11'
-__date__ = '07 Jul 2021'
+__version__ = '3.0.12'
+__date__ = '14 Jul 2021'
 
 
 import sys

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info[0] < 3:
 
 setuptools.setup(
     name='MetaPhlAn',
-    version='3.0.11',
+    version='3.0.12',
     author='Francesco Beghini',
     author_email='francesco.beghini@unitn.it',
     url='http://github.com/biobakery/MetaPhlAn/',


### PR DESCRIPTION
Here are a few proposed changes to implement Eric's rpks_any method for the unknown estimate. The final small change uses the kingdom level nodes for computing the estimate instead of those at the species level (which mainly changes the estimate for genome length).

All changes use the existing framework to try to be as modular and reusable as possible going forward. For efficiency we could add a conditional so the unknown estimate TaxTree is not created/computed if the unknown estimate is not requested by the user but I think this should only reduce the compute time by a few minutes. 

There are no changes to the core relative abundance calculation. This has been tested and confirmed. The final relative abundance outputs are changed only due to the change in the fraction of mapped reads. This change is required so that the abundances and the unknown estimate sum to 100.

Changes:
* Roll back to v3.0.9 unknown estimate and relative abundance calculation
* Remove trimming of markers by quantiles
* Change genome length to use median and add boost to length of 1.05
* Check and address corner cases (negative and zero)
* Change unknown estimate from species to kingdom level

Please reach out to me here or on slack with any questions or any changes you would like me to make.

Thank you,
Lauren