### PR TITLE
Use tempfile for marker file for extract_markers.py

### DIFF
--- a/metaphlan/utils/external_exec.py
+++ b/metaphlan/utils/external_exec.py
@@ -6,7 +6,7 @@ __author__ = ('Aitor Blanco Miguez (aitor.blancomiguez@unitn.it), '
 __version__ = '3.0.8'
 __date__ = '7 May 2021'
 
-import os, sys, re, shutil
+import os, sys, re, shutil, tempfile
 import subprocess as sb
 try:
     from .util_fun import info, error
@@ -245,7 +245,9 @@ Generates a FASTA file with the markers form a MetaPhlAn database
 :param output_dir: the output directory
 """
 def generate_markers_fasta(database, output_dir):
-    db_markers_faa = output_dir+"db_markers.fna"
+    
+    file_out, db_markers_faa = tempfile.mkstemp(dir=output_dir,prefix="db_markers_temp_",suffix=".fna")
+    os.close(file_out)
     bowtie_database, _ = os.path.splitext(database)
     params = {
         "program_name" : "bowtie2-inspect",


### PR DESCRIPTION
Hello Aitor and Francesco,

The bioBakery workflows can run multiple extract_markers.py tasks at once, one for each species selected for the StrainPhlAn runs. I noticed there existed a race condition where these tasks will all try to write and then read from the same temp markers file since the workflow places all of the markers in the same folder. It does this in part because it does not know the name of the species until each task is run so part of the command has to be dynamic. 

I made a really small change to the extract_markers.py function "generate_markers_fasta" to write to a tempfile. This will resolve the race condition as all of the temp files should have unique names. 

Please check it out and let me know what you think. 

Thank you!
Lauren