### PR TITLE
Fix `UnboundLocalError: local variable 'idx' referenced before assignment` for single read input files

### DIFF
--- a/metaphlan/utils/read_fastx.py
+++ b/metaphlan/utils/read_fastx.py
@@ -61,6 +61,7 @@ def read_and_write_raw_int(fd, min_len=None, prefix_id=""):
     avg_read_length = 0
     nreads = 0
     discarded = 0
+    idx = 1
     #if min_len:
     r = []
 


### PR DESCRIPTION
Single read input files cause an `UnboundLocalError: local variable 'idx' referenced before assignment` error due to the `idx` variable never being set in `read_and_write_raw_int`.
This PR fixes this by pre-initialising the `idx` variable.