### PR TITLE
Changing metaphlan2krona.py to stop at the species level and fixes parsing errors with latest 4.2.* format

### DIFF
--- a/metaphlan/utils/metaphlan2krona.py
+++ b/metaphlan/utils/metaphlan2krona.py
@@ -41,8 +41,7 @@ def main():
             x = re.sub(re_replace, '\t', lin)
             lineage = re.sub(re_bar, '', x)
             abundance = float(frac.rstrip('\n'))
-            metaPhLan_FH.write(f'{abundance}\t{lineage}\t{tax}\n')
-
+            metaPhLan_FH.write(f'{abundance}\t{tax}\t{lineage}\n')
     metaPhLan_FH.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

The current metaphlan2krona.py script currently fails for some profile outputs from the current 4.2.* versions of metaphlan.
In some cases, there are multiple lineages on one line (this should probably be fixed in a separate PR), and the abundance is not extracted properly.

This PR fixes this by stopping at the 't__' lines, and I changed the logic for how to extract the abundances and lineages.
I also changed the order so it's easier to use the file with the Krona script ktImportTaxonomy.sh.

